### PR TITLE
Update Paseto link

### DIFF
--- a/projects.md
+++ b/projects.md
@@ -9,7 +9,7 @@ The table below shows what the project is titled, a short description of the pro
 | **Name** | **Short description** | **Android**  | **Java** |
 | :--- | :--- | :--- | :--- |
 | \*\*\*\*[**Lazysodium: The Android App**](https://play.google.com/store/apps/details?id=com.goterl.lazycode.lazysodium.example&pcampaignid=MKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1) | Download our open-source app that showcases some of Lazysodium's features. | ✓ | ✗ |
-| \*\*\*\*[**Paseto**](https://paseto.io/)\*\*\*\* | Java Implementation of Platform-Agnostic Security Tokens.  | ✗ | ✓ |
+| \*\*\*\*[**Paseto**](https://github.com/atholbro/paseto)\*\*\*\* | Java Implementation of Platform-Agnostic Security Tokens.  | ✗ | ✓ |
 | \*\*\*\*[**Recordo**](https://recordo.co)\*\*\*\* | A super secure diary/journal that provides end to end encryption. | ✓ | ✓ |
 
 


### PR DESCRIPTION
Hey,

I noticed the link to Paseto points to the overall project page, but seeing as this is directly about LazySodium, I think it should link directly to the Java implementation. So that's what this pull request changes.